### PR TITLE
upgrade to Node.js v6.10.0 LTS

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -164,7 +164,7 @@
               <goal>install-node-and-npm</goal>
             </goals>
             <configuration>
-              <nodeVersion>v6.2.0</nodeVersion>
+              <nodeVersion>v6.10.0</nodeVersion>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
Frontend maven plugin fails to download Node.js v6.2.0 on Windows system and 64  bits architecture because https://nodejs.org/dist/v6.2.0/node-v6.2.0-win-x64.zip doesn't exsist.